### PR TITLE
Fix subsegment chopping to return segments in turn.

### DIFF
--- a/src/osmlr.cpp
+++ b/src/osmlr.cpp
@@ -178,7 +178,7 @@ bool check_access(vb::GraphReader &reader, const vb::merge::path &p) {
     access &= edge->forwardaccess();
 
     // if any edge is a shortcut, then drop the whole path
-    if (edge->shortcut()) {
+    if (edge->is_shortcut()) {
       return false;
     }
 


### PR DESCRIPTION
Fix subsegment code to remove the 'chopped' subsegment, so that subsequent segments follow on from that shape. The bug previously was that every segment would be the first `dist` length of the shape, and therefore have the same bearing and other LR parameters.

@dnesbitt61 could you review, please?