### PR TITLE
Update OSMLR segment definitions to not exceed kMaximumLength (1km for now).

### DIFF
--- a/include/osmlr/output/geojson.hpp
+++ b/include/osmlr/output/geojson.hpp
@@ -13,6 +13,11 @@ struct geojson : public output {
   virtual ~geojson();
 
   void add_path(const valhalla::baldr::merge::path &);
+  void output_segment(const valhalla::baldr::merge::path &p);
+  void output_segment(const std::vector<valhalla::midgard::PointLL>& shape,
+                      const valhalla::baldr::DirectedEdge* edge,
+                      const valhalla::baldr::GraphId& edgeid);
+  void split_path(const valhalla::baldr::merge::path& p, const uint32_t total_length);
   void finish();
 
 private:

--- a/include/osmlr/output/tiles.hpp
+++ b/include/osmlr/output/tiles.hpp
@@ -7,17 +7,67 @@
 namespace osmlr {
 namespace output {
 
+enum class FormOfWay {
+  kUndefined = 0,
+  kMotorway = 1,
+  kMultipleCarriageway = 2,
+  kSingleCarriageway = 3,
+  kRoundabout = 4,
+  kTrafficSquare = 5,
+  kSlipRoad = 6,
+  kOther = 7
+};
+
+struct lrp {
+  bool at_node;
+  const valhalla::midgard::PointLL coord;
+  const uint16_t bear;
+  const valhalla::baldr::RoadClass start_frc;
+  const FormOfWay start_fow;
+  const valhalla::baldr::RoadClass least_frc;
+  const uint32_t length;
+
+  lrp(const bool at_node_,
+      const valhalla::midgard::PointLL &coord_,
+      uint16_t bear_,
+      valhalla::baldr::RoadClass start_frc_,
+      FormOfWay start_fow_,
+      valhalla::baldr::RoadClass least_frc_,
+      uint32_t length_)
+    : at_node(at_node_)
+    , coord(coord_)
+    , bear(bear_)
+    , start_frc(start_frc_)
+    , start_fow(start_fow_)
+    , least_frc(least_frc_)
+    , length(length_)
+    {}
+};
+
 struct tiles : public output {
   tiles(valhalla::baldr::GraphReader &reader, std::string base_dir, size_t max_fds, uint32_t max_length = 15000);
   virtual ~tiles();
 
-  void add_path(const valhalla::baldr::merge::path &);
+  void add_path(const valhalla::baldr::merge::path &p);
+  void split_path(const valhalla::baldr::merge::path &p, const uint32_t total_length);
+  void output_segment(const valhalla::baldr::merge::path &p);
+  void output_segment(const std::vector<valhalla::midgard::PointLL>& shape,
+                      const valhalla::baldr::DirectedEdge* edge,
+                      const valhalla::baldr::GraphId& edgeid,
+                      const bool start_at_node, const bool end_at_node);
+  void output_segment(std::vector<lrp>& lrps, const valhalla::baldr::GraphId& tile_id);
   void finish();
 
 private:
   valhalla::baldr::GraphReader &m_reader;
   util::tile_writer m_writer;
   uint32_t m_max_length;
+
+  std::vector<lrp> build_segment_descriptor(const valhalla::baldr::merge::path &p);
+  std::vector<lrp> build_segment_descriptor(const std::vector<valhalla::midgard::PointLL>& shape,
+                                            const valhalla::baldr::DirectedEdge* edge,
+                                            const bool start_at_node,
+                                            const bool end_at_node);
 };
 
 } // namespace output

--- a/src/output/geojson.cpp
+++ b/src/output/geojson.cpp
@@ -1,9 +1,16 @@
 #include "osmlr/output/geojson.hpp"
 #include <stdexcept>
 
+namespace vm = valhalla::midgard;
 namespace vb = valhalla::baldr;
 
 namespace {
+
+// Minimum length for an OSMLR segment
+constexpr uint32_t kMinimumLength = 5;
+
+// Maximum length for an OSMLR segment
+constexpr uint32_t kMaximumLength = 1000;
 
 const std::string k_geojson_header = "{\"type\":\"FeatureCollection\",\"features\":[";
 const std::string k_geojson_footer = "]}";
@@ -12,6 +19,43 @@ const std::string k_geojson_footer = "]}";
 // no reverse vehicular access is allowed
 bool is_oneway(const vb::DirectedEdge *e) {
   return (e->reverseaccess() & vb::kVehicularAccess) == 0;
+}
+
+vm::PointLL interp(vm::PointLL a, vm::PointLL b, double frac) {
+  return vm::PointLL(a.AffineCombination(1.0 - frac, frac, b));
+}
+
+// chop the first "dist" length off seg, returning it as the result. this will
+// modify seg!
+std::vector<vm::PointLL> chop_subsegment(std::vector<vm::PointLL> &seg, uint32_t dist) {
+  const size_t len = seg.size();
+  assert(len > 1);
+  std::vector<vm::PointLL> result;
+  result.push_back(seg[0]);
+  double d = 0.0;
+  size_t i = 1;
+  for (; i < len; ++i) {
+    auto segdist = seg[i-1].Distance(seg[i]);
+    if ((d + segdist) >= dist) {
+      double frac = (static_cast<double>(dist) - d) / segdist;
+      auto midpoint = interp(seg[i-1], seg[i], frac);
+      result.push_back(midpoint);
+      // remove used part of seg.
+      seg.erase(seg.begin(), (seg.begin() + (i - 1)));
+      seg[0] = midpoint;
+      break;
+
+    } else {
+      d += segdist;
+      result.push_back(seg[i]);
+    }
+  }
+
+  // used all of seg, and exited the loop by iteration rather than breaking out.
+  if (i == len) {
+    seg.clear();
+  }
+  return result;
 }
 
 } // anonymous namespace
@@ -28,6 +72,97 @@ geojson::~geojson() {
 }
 
 void geojson::add_path(const vb::merge::path &p) {
+  // Get the length of the path
+  uint32_t total_length = 0;
+  for (auto edge_id : p.m_edges) {
+    const auto *tile = m_reader.GetGraphTile(edge_id);
+    const auto *edge = tile->directededge(edge_id);
+    total_length += edge->length();
+  }
+
+  // Skip very short segments that are only 1 edge
+  if (total_length < kMinimumLength && p.m_edges.size() == 1) {
+    return;
+  }
+
+  // Split longer segments
+  if (total_length < kMaximumLength) {
+    output_segment(p);
+  } else {
+    split_path(p, total_length);
+  }
+}
+
+void geojson::split_path(const vb::merge::path& p, const uint32_t total_length) {
+  // Walk the merged path and split where needed
+  uint32_t accumulated_length = 0;
+  vb::merge::path split_path(p.m_start);
+  for (auto edge_id : p.m_edges) {
+    // TODO - do we need to check if we enter a new tile or does the writer
+    // handle this?
+
+    const auto* tile = m_reader.GetGraphTile(edge_id);
+    const auto* edge = tile->directededge(edge_id);
+    uint32_t edge_len = edge->length();
+
+    if (edge_len >= kMaximumLength) {
+      // Output prior segment
+      if (split_path.m_edges.size() > 0) {
+        output_segment(split_path);
+      }
+
+      // TODO - split this edge - for now just add the entire edge
+      uint32_t edgeinfo_offset = edge->edgeinfo_offset();
+      auto edgeinfo = tile->edgeinfo(edgeinfo_offset);
+      std::vector<PointLL> shape = tile->edgeinfo(edge->edgeinfo_offset()).shape();
+      if (!edge->forward()) {
+        std::reverse(shape.begin(), shape.end());
+      }
+
+      float shape_length = length(shape);
+
+      // Split the edge
+      int n = (edge_len / kMaximumLength);
+      float dist = static_cast<float>(edge_len) / static_cast<float>(n+1);
+      uint32_t d = std::ceil(dist);
+      for (int i = 0; i < n; i++) {
+       // if (shape.size() == 0) break;
+        auto sub_shape = chop_subsegment(shape, d);
+        output_segment(sub_shape, edge, edge_id);
+      }
+      if (shape.size() > 0) {
+        output_segment(shape, edge, edge_id);
+      }
+
+      // Start a new path at the end of this edge
+      split_path.m_start = edge->endnode();
+      split_path.m_edges.clear();
+      accumulated_length = 0;
+    } else if (accumulated_length + edge_len >= kMaximumLength) {
+      // TODO - optimize the split to avoid short segments
+
+      // Output the current split path and start a new split path
+      output_segment(split_path);
+      split_path.m_start = split_path.m_end;
+      split_path.m_edges.clear();
+      split_path.m_edges.push_back(edge_id);
+      split_path.m_end = edge->endnode();
+      accumulated_length = edge_len;
+    } else {
+      // Add this edge to the new path
+      split_path.m_edges.push_back(edge_id);
+      split_path.m_end = edge->endnode();
+      accumulated_length += edge_len;
+    }
+  }
+
+  // Output the last
+  if (split_path.m_edges.size() > 0) {
+    output_segment(split_path);
+  }
+}
+
+void geojson::output_segment(const vb::merge::path &p) {
   std::ostringstream out;
   out.precision(17);
 
@@ -90,6 +225,55 @@ void geojson::add_path(const vb::merge::path &p) {
     out << edge_id;
   }
 
+  out << "\"}}";
+
+  m_writer.write_to(tile_id, out.str());
+  tile_path_itr->second += 1;
+}
+
+// Output a segment that is part of an edge.
+void geojson::output_segment(const std::vector<vm::PointLL>& shape,
+                             const vb::DirectedEdge* edge,
+                             const vb::GraphId& edgeid) {
+  std::ostringstream out;
+  out.precision(17);
+
+  auto tile_id = edgeid.Tile_Base();
+
+  auto tile_path_itr = m_tile_path_ids.find(tile_id);
+  if (tile_path_itr == m_tile_path_ids.end()) {
+    out << k_geojson_header;
+    std::tie(tile_path_itr, std::ignore) = m_tile_path_ids.emplace(tile_id, 0);
+  } else {
+    out << ",";
+  }
+
+  out << "{\"type\":\"Feature\",\"geometry\":";
+  out << "{\"type\":\"MultiLineString\",\"coordinates\":[";
+  out << "[";
+  bool first_pt = true;
+  for (const auto pt : shape) {
+    if (first_pt) { first_pt = false; } else { out << ","; }
+    out << "[" << pt.lng() << "," << pt.lat() << "]";
+  }
+  out << "]";
+
+  vb::GraphId osmlr_id(tile_id.tileid(), tile_id.level(), tile_path_itr->second);
+  bool first = true;
+  bool oneway = is_oneway(edge);
+  bool drive_on_right = edge->drive_on_right();
+  vb::RoadClass best_frc = edge->classification();
+  out << "]},\"properties\":{"
+      << "\"tile_id\":" << tile_id.tileid() << ","
+      << "\"level\":" << tile_id.level() << ","
+      << "\"id\":" << tile_path_itr->second << ","
+      << "\"osmlr_id\":" << osmlr_id.value << ","
+      << "\"best_frc\":\"" << vb::to_string(best_frc) << "\","
+      << "\"oneway\":" << oneway << ","
+      << "\"drive_on_right\":" << drive_on_right << ","
+      << "\"original_edges\":\"";
+
+  out << edgeid;
   out << "\"}}";
 
   m_writer.write_to(tile_id, out.str());

--- a/src/output/tiles.cpp
+++ b/src/output/tiles.cpp
@@ -1,6 +1,8 @@
 #include "osmlr/output/tiles.hpp"
 #include "segment.pb.h"
 #include "tile.pb.h"
+#include <valhalla/midgard/logging.h>
+#include <valhalla/midgard/util.h>
 #include <stdexcept>
 
 namespace vm = valhalla::midgard;
@@ -9,13 +11,16 @@ namespace pbf = opentraffic::osmlr;
 
 namespace {
 
+// Minimum length for an OSMLR segment
+constexpr uint32_t kMinimumLength = 5;
+
+// Maximum length for an OSMLR segment
+constexpr uint32_t kMaximumLength = 1000;
+
 // Local stats for testing
 int count = 0;
 int shortsegs = 0;
 int longsegs = 0;
-int roundabout = 0;
-int internal = 0;
-int turnchannel = 0;
 float accum = 0.0f;
 
 uint16_t bearing(const std::vector<vm::PointLL> &shape) {
@@ -44,16 +49,58 @@ bool is_oneway(const vb::DirectedEdge *e) {
   return (e->reverseaccess() & vb::kVehicularAccess) == 0;
 }
 
-enum class FormOfWay {
-  kUndefined = 0,
-  kMotorway = 1,
-  kMultipleCarriageway = 2,
-  kSingleCarriageway = 3,
-  kRoundabout = 4,
-  kTrafficSquare = 5,
-  kSlipRoad = 6,
-  kOther = 7
-};
+
+vm::PointLL interp(vm::PointLL a, vm::PointLL b, double frac) {
+  return vm::PointLL(a.AffineCombination(1.0 - frac, frac, b));
+}
+
+// chop the first "dist" length off seg, returning it as the result. this will
+// modify seg!
+std::vector<vm::PointLL> chop_subsegment(std::vector<vm::PointLL> &seg, uint32_t dist) {
+  const size_t len = seg.size();
+  assert(len > 1);
+  std::vector<vm::PointLL> result;
+  result.push_back(seg[0]);
+  double d = 0.0;
+  size_t i = 1;
+  for (; i < len; ++i) {
+    auto segdist = seg[i-1].Distance(seg[i]);
+    if ((d + segdist) >= dist) {
+      double frac = (static_cast<double>(dist) - d) / segdist;
+      auto midpoint = interp(seg[i-1], seg[i], frac);
+      result.push_back(midpoint);
+      // remove used part of seg.
+      seg.erase(seg.begin(), (seg.begin() + (i - 1)));
+      seg[0] = midpoint;
+      break;
+
+    } else {
+      d += segdist;
+      result.push_back(seg[i]);
+    }
+  }
+
+  // used all of seg, and exited the loop by iteration rather than breaking out.
+  if (i == len) {
+    seg.clear();
+  }
+  return result;
+}
+
+pbf::Segment_RoadClass convert_frc(vb::RoadClass rc) {
+  assert(pbf::Segment_RoadClass_IsValid(int(rc)));
+  return pbf::Segment_RoadClass(int(rc));
+}
+
+} // anonymous namespace
+
+namespace osmlr {
+namespace output {
+
+pbf::Segment_FormOfWay convert_fow(FormOfWay fow) {
+  assert(pbf::Segment_FormOfWay_IsValid(int(fow)));
+  return pbf::Segment_FormOfWay(int(fow));
+}
 
 std::ostream &operator<<(std::ostream &out, FormOfWay fow) {
   switch (fow) {
@@ -73,14 +120,6 @@ std::ostream &operator<<(std::ostream &out, FormOfWay fow) {
 FormOfWay form_of_way(const vb::DirectedEdge *e) {
   bool oneway = is_oneway(e);
   auto rclass = e->classification();
-
-  // stats
-  if (e->internal()){
-    internal++;
-  }
-  if (e->use() == vb::Use::kTurnChannel) {
-    turnchannel++;
-  }
 
   // if it's a slip road, return that. TODO: am i doing this right?
   if (e->link()) {
@@ -109,189 +148,6 @@ FormOfWay form_of_way(const vb::DirectedEdge *e) {
   }
 }
 
-struct lrp {
-  const vm::PointLL coord;
-  const uint16_t bear;
-  const vb::RoadClass start_frc;
-  const FormOfWay start_fow;
-  const vb::RoadClass least_frc;
-  const uint32_t length;
-
-  lrp(const vm::PointLL &coord_,
-      uint16_t bear_,
-      vb::RoadClass start_frc_,
-      FormOfWay start_fow_,
-      vb::RoadClass least_frc_,
-      uint32_t length_)
-    : coord(coord_)
-    , bear(bear_)
-    , start_frc(start_frc_)
-    , start_fow(start_fow_)
-    , least_frc(least_frc_)
-    , length(length_)
-    {}
-};
-
-vm::PointLL interp(vm::PointLL a, vm::PointLL b, double frac) {
-  return vm::PointLL(a.AffineCombination(1.0 - frac, frac, b));
-}
-
-// chop the first "dist" length off seg, returning it as the result. this will
-// modify seg!
-std::vector<vm::PointLL> chop_subsegment(std::vector<vm::PointLL> &seg, uint32_t dist) {
-  const size_t len = seg.size();
-  assert(len > 1);
-
-  std::vector<vm::PointLL> result;
-  result.push_back(seg[0]);
-  double d = 0.0;
-  size_t i = 1;
-  for (; i < len; ++i) {
-    auto segdist = seg[i-1].Distance(seg[i]);
-    if ((d + segdist) >= dist) {
-      double frac = (dist - d) / segdist;
-      auto midpoint = interp(seg[i-1], seg[i], frac);
-      result.push_back(midpoint);
-      // remove used part of seg.
-      seg.erase(seg.begin(), seg.begin() + (i - 1));
-      seg[0] = midpoint;
-      break;
-
-    } else {
-      d += segdist;
-      result.push_back(seg[i]);
-    }
-  }
-
-  // used all of seg, and exited the loop by iteration rather than breaking out.
-  if (i == len) {
-    seg.clear();
-  }
-
-  return result;
-}
-
-std::vector<lrp> build_segment_descriptor(vb::GraphReader &reader, const vb::merge::path &p, uint32_t max_length) {
-  assert(p.m_edges.size() > 0);
-
-  std::vector<lrp> seg;
-
-  uint32_t accumulated_length = 0;
-  vb::GraphId last_node = p.m_start;
-  vb::GraphId start_node = p.m_start;
-  std::vector<vm::PointLL> shape;
-  vm::PointLL last_point_seen;
-  vb::RoadClass start_frc, least_frc;
-  FormOfWay start_fow;
-
-  for (auto edge_id : p.m_edges) {
-    const auto *tile = reader.GetGraphTile(edge_id);
-    const auto *edge = tile->directededge(edge_id);
-    uint32_t edgeinfo_offset = edge->edgeinfo_offset();
-    auto edgeinfo = tile->edgeinfo(edgeinfo_offset);
-    uint32_t edge_len = edge->length();
-
-    if (edge_len + accumulated_length >= max_length && start_node != last_node) {
-      assert(shape.size() > 0);
-      uint16_t bear = bearing(shape);
-      seg.emplace_back(shape[0], bear, start_frc, start_fow, least_frc, accumulated_length);
-      accumulated_length = 0;
-      start_node = last_node;
-      last_point_seen = shape.back();
-      shape.clear();
-      start_frc = edge->classification();
-      least_frc = start_frc;
-      start_fow = form_of_way(edge);
-    }
-
-    std::vector<vm::PointLL> full_shape = edgeinfo.shape();
-    if (!edge->forward()) {
-      std::reverse(full_shape.begin(), full_shape.end());
-    }
-
-    if (edge_len >= max_length) {
-      // check we've already flushed the previous edge
-      assert(accumulated_length == 0);
-
-      const auto frc = edge->classification();
-      const auto fow = form_of_way(edge);
-
-      const uint32_t num_segs = (edge_len / max_length) + 1;
-      for (uint32_t i = 0; i < num_segs; ++i) {
-        uint32_t start_dist = (i * edge_len) / num_segs;
-        uint32_t end_dist = ((i+1) * edge_len) / num_segs;
-        assert(end_dist - start_dist < max_length);
-
-        // Since full_shape is chopped in this method make sure we use
-        // end_dist - start_dist as distance along the shape to chop
-        shape = chop_subsegment(full_shape, end_dist - start_dist);
-        assert(!shape.empty());
-        uint16_t bear = bearing(shape);
-
-        seg.emplace_back(shape[0], bear, frc, fow, frc, end_dist - start_dist);
-      }
-
-      accumulated_length = 0;
-      start_node = edge->endnode();
-      last_point_seen = shape.back();
-      shape.clear();
-
-    } else {
-      if (accumulated_length == 0) {
-        start_frc = edge->classification();
-        least_frc = start_frc;
-        start_fow = form_of_way(edge);
-      }
-      if (edge->classification() < least_frc) {
-        least_frc = edge->classification();
-      }
-      accumulated_length += edge_len;
-      shape.insert(shape.end(), full_shape.begin(), full_shape.end());
-    }
-
-    last_node = edge->endnode();
-  }
-
-  if (accumulated_length > 0) {
-    assert(shape.size() > 0);
-    seg.emplace_back(shape[0], bearing(shape), start_frc, start_fow, least_frc, accumulated_length);
-    last_point_seen = shape.back();
-  }
-
-  // output last LRP
-  assert(last_point_seen.IsValid());
-  assert(last_point_seen.lat() != 0.0);
-  seg.emplace_back(last_point_seen, 0, start_frc, start_fow, least_frc, 0);
-
-  // Update stats
-  count++;
-  accum += accumulated_length;
-  if (accumulated_length < 25) {
-    shortsegs++;
-  } else if (accumulated_length > 2000) {
-    longsegs++;
-  }
-  if (start_fow == FormOfWay::kRoundabout) {
-    roundabout++;
-  }
-  return seg;
-}
-
-pbf::Segment_RoadClass convert_frc(vb::RoadClass rc) {
-  assert(pbf::Segment_RoadClass_IsValid(int(rc)));
-  return pbf::Segment_RoadClass(int(rc));
-}
-
-pbf::Segment_FormOfWay convert_fow(FormOfWay fow) {
-  assert(pbf::Segment_FormOfWay_IsValid(int(fow)));
-  return pbf::Segment_FormOfWay(int(fow));
-}
-
-} // anonymous namespace
-
-namespace osmlr {
-namespace output {
-
 tiles::tiles(vb::GraphReader &reader, std::string base_dir, size_t max_fds, uint32_t max_length)
   : m_reader(reader)
   , m_writer(base_dir, "osmlr", max_fds)
@@ -301,18 +157,204 @@ tiles::tiles(vb::GraphReader &reader, std::string base_dir, size_t max_fds, uint
 tiles::~tiles() {
 }
 
+void tiles::split_path(const vb::merge::path& p, const uint32_t total_length) {
+  // Walk the merged path and split where needed
+  uint32_t accumulated_length = 0;
+  vb::merge::path split_path(p.m_start);
+  for (auto edge_id : p.m_edges) {
+    // TODO - do we need to check if we enter a new tile or does the writer
+    // handle this?
+
+    const auto* tile = m_reader.GetGraphTile(edge_id);
+    const auto* edge = tile->directededge(edge_id);
+    uint32_t edge_len = edge->length();
+
+    if (edge_len >= kMaximumLength) {
+      // Output prior segment
+      if (split_path.m_edges.size() > 0) {
+        output_segment(split_path);
+      }
+
+      // Split this edge
+      uint32_t edgeinfo_offset = edge->edgeinfo_offset();
+      auto edgeinfo = tile->edgeinfo(edgeinfo_offset);
+      std::vector<PointLL> shape = tile->edgeinfo(edge->edgeinfo_offset()).shape();
+      if (!edge->forward()) {
+        std::reverse(shape.begin(), shape.end());
+      }
+      int n = (edge_len / kMaximumLength);
+      float dist = static_cast<float>(edge_len) / static_cast<float>(n+1);
+      for (int i = 0; i < n; i++) {
+        auto sub_shape = chop_subsegment(shape, std::ceil(dist));
+        output_segment(sub_shape, edge, edge_id, (i==0), false);
+      }
+      if (shape.size() > 0) {
+        output_segment(shape, edge, edge_id, false, true);
+      }
+
+      // Start a new path at the end of this edge
+      split_path.m_start = edge->endnode();
+      split_path.m_edges.clear();
+      accumulated_length = 0;
+    } else if (accumulated_length + edge_len >= kMaximumLength) {
+      // TODO - optimize the split to avoid short segments
+
+      // Output the current split path and start a new split path
+      output_segment(split_path);
+      split_path.m_start = split_path.m_end;
+      split_path.m_edges.clear();
+      split_path.m_edges.push_back(edge_id);
+      split_path.m_end = edge->endnode();
+      accumulated_length = edge_len;
+    } else {
+      // Add this edge to the new path
+      split_path.m_edges.push_back(edge_id);
+      split_path.m_end = edge->endnode();
+      accumulated_length += edge_len;
+    }
+  }
+
+  // Output the last
+  if (split_path.m_edges.size() > 0) {
+    output_segment(split_path);
+  }
+}
+
 void tiles::add_path(const vb::merge::path &p) {
-  auto tile_id = p.m_start.Tile_Base();
+  // Get the length of the path
+  uint32_t total_length = 0;
+  for (auto edge_id : p.m_edges) {
+    const auto *tile = m_reader.GetGraphTile(edge_id);
+    const auto *edge = tile->directededge(edge_id);
+    total_length += edge->length();
+  }
 
-  std::vector<lrp> lrps = build_segment_descriptor(m_reader, p, m_max_length);
+  // Skip very short segments that are only 1 edge
+  if (total_length < kMinimumLength && p.m_edges.size() == 1) {
+    return;
+  }
 
-  // this appends a tile with only a single entry. each repeated message (not a
-  // packed=true primitive) in the protocol buffers format is tagged with the
-  // field number. this means the concatenation of two messages consisting only
-  // of repeated fields is a valid message with those fields concatenated. since
-  // there is no Tile header at this time, we can just concatenate individual
-  // Tile messages to make the full Tile. this means we don't have to track any
-  // additional state for each Tile being built.
+  // Split longer segments
+  if (total_length < kMaximumLength) {
+    output_segment(p);
+  } else {
+    split_path(p, total_length);
+  }
+}
+
+// Build a segment descriptor for a portion of an edge. This requires the
+// portion of the edge shape and the directed edge.
+std::vector<lrp> tiles::build_segment_descriptor(const std::vector<vm::PointLL>& shape,
+                                                 const vb::DirectedEdge* edge,
+                                                 const bool start_at_node,
+                                                 const bool end_at_node) {
+  assert(shape.size() > 0);
+
+  std::vector<lrp> seg;
+  vb::RoadClass frc = edge->classification();
+  FormOfWay fow = form_of_way(edge);
+
+  // Output first LRP. TODO - set at_node flag
+  float accumulated_length = length(shape);
+  seg.emplace_back(start_at_node, shape[0], bearing(shape), frc, fow, frc, accumulated_length);
+
+  // Output last LRP
+  seg.emplace_back(end_at_node, shape.back(), 0, frc, fow, frc, 0);
+
+  // Update stats for total, short, and long segments. Add 10 to max segment
+  // length to account for roundoff.
+  count++;
+  accum += accumulated_length;
+  if (accumulated_length < 25) {
+    LOG_INFO("accumulated length = " + std::to_string(accumulated_length));
+    shortsegs++;
+  } else if (accumulated_length > kMaximumLength+10) {
+    LOG_INFO("accumulated length = " + std::to_string(accumulated_length));
+    longsegs++;
+  }
+  return seg;
+}
+
+
+// Build segment LRPs for a single segment. The first LRP is at the beginning node of the path
+// and the last LRP is at the end edge in the path
+std::vector<lrp> tiles::build_segment_descriptor(const vb::merge::path &p) {
+  assert(p.m_edges.size() > 0);
+
+  std::vector<lrp> seg;
+  uint32_t accumulated_length = 0;
+  vb::GraphId last_node = p.m_start;
+  std::vector<vm::PointLL> shape;
+  vb::RoadClass start_frc, least_frc;
+  FormOfWay start_fow;
+  for (auto edge_id : p.m_edges) {
+    const auto* tile = m_reader.GetGraphTile(edge_id);
+    const auto* edge = tile->directededge(edge_id);
+    uint32_t edge_len = edge->length();
+
+    // First edge - get the shape so we can get bearing. Get FRC and FOW
+    if (accumulated_length == 0) {
+      shape = tile->edgeinfo(edge->edgeinfo_offset()).shape();
+      if (!edge->forward()) {
+        std::reverse(shape.begin(), shape.end());
+      }
+      start_frc = edge->classification();
+      least_frc = start_frc;
+      start_fow = form_of_way(edge);
+    }
+    if (edge->classification() < least_frc) {
+      least_frc = edge->classification();
+    }
+    accumulated_length += edge_len;
+    last_node = edge->endnode();
+  }
+
+  // Output the start LRP
+  if (accumulated_length > 0) {
+    assert(shape.size() > 0);
+    seg.emplace_back(true, shape[0], bearing(shape), start_frc, start_fow,
+                     least_frc, accumulated_length);
+  }
+
+  // output last LRP
+  const auto* tile = m_reader.GetGraphTile(last_node);
+  vm::PointLL endll = tile->node(last_node)->latlng();
+  seg.emplace_back(true, endll, 0, start_frc, start_fow, least_frc, 0);
+
+  // Update stats
+  count++;
+  accum += accumulated_length;
+  if (accumulated_length < 25) {
+    shortsegs++;
+  } else if (accumulated_length > kMaximumLength) {
+    LOG_INFO("path accumulated length = " + std::to_string(accumulated_length));
+    longsegs++;
+  }
+  return seg;
+}
+
+// this appends a tile with only a single entry. each repeated message (not a
+// packed=true primitive) in the protocol buffers format is tagged with the
+// field number. this means the concatenation of two messages consisting only
+// of repeated fields is a valid message with those fields concatenated. since
+// there is no Tile header at this time, we can just concatenate individual
+// Tile messages to make the full Tile. this means we don't have to track any
+// additional state for each Tile being built.
+void tiles::output_segment(const vb::merge::path &p) {
+  auto lrps = build_segment_descriptor(p);
+  output_segment(lrps, p.m_start.Tile_Base());
+}
+
+void tiles::output_segment(const std::vector<vm::PointLL>& shape,
+                           const vb::DirectedEdge* edge,
+                           const vb::GraphId& edgeid,
+                           const bool start_at_node, const bool end_at_node) {
+  auto lrps = build_segment_descriptor(shape, edge, start_at_node, end_at_node);
+  output_segment(lrps, edgeid.Tile_Base());
+}
+
+void tiles::output_segment(std::vector<lrp>& lrps,
+                           const vb::GraphId& tile_id) {
   pbf::Tile tile;
   auto *entry = tile.add_entries();
   // don't (yet) support deleted entries, so every entry is a Segment.
@@ -327,7 +369,7 @@ void tiles::add_path(const vb::merge::path &p) {
     auto *coord = pb_lrp->mutable_coord();
     coord->set_lat(int32_t(lrp.coord.lat() * 1.0e7));
     coord->set_lng(int32_t(lrp.coord.lng() * 1.0e7));
-
+    pb_lrp->set_at_node(lrp.at_node);
     pb_lrp->set_bear(lrp.bear);
     pb_lrp->set_start_frc(convert_frc(lrp.start_frc));
     pb_lrp->set_start_fow(convert_fow(lrp.start_fow));
@@ -336,14 +378,12 @@ void tiles::add_path(const vb::merge::path &p) {
   }
 
   // final LRP with just a coord
-  {
-    auto *pb_lrp = segment->add_lrps();
-    const auto &lrp = lrps[lrps.size() - 1];
-
-        auto *coord = pb_lrp->mutable_coord();
-    coord->set_lat(int32_t(lrp.coord.lat() * 1.0e7));
-    coord->set_lng(int32_t(lrp.coord.lng() * 1.0e7));
-  }
+  auto *pb_lrp = segment->add_lrps();
+  const auto &lrp = lrps[lrps.size() - 1];
+  auto *coord = pb_lrp->mutable_coord();
+  pb_lrp->set_at_node(lrp.at_node);
+  coord->set_lat(int32_t(lrp.coord.lat() * 1.0e7));
+  coord->set_lng(int32_t(lrp.coord.lng() * 1.0e7));
 
   std::string buf;
   if (!tile.SerializeToString(&buf)) {
@@ -352,14 +392,12 @@ void tiles::add_path(const vb::merge::path &p) {
   m_writer.write_to(tile_id, buf);
 }
 
+
 void tiles::finish() {
   // Output some simple stats
   float avg = accum / count;
   std::cout << "count = " << count << " shortsegs = " << shortsegs <<
           " longsegs " << longsegs << std::endl;
-  std::cout << "roundabouts = " << roundabout << std::endl;
-  std::cout << "internal = " << internal << std::endl;
-  std::cout << "turn channels = " << turnchannel << std::endl;
   std::cout << "average length = " << avg << std::endl;
 
   // because protobuf Tile messages can be concatenated and there's no footer to

--- a/src/output/tiles.cpp
+++ b/src/output/tiles.cpp
@@ -50,44 +50,6 @@ bool is_oneway(const vb::DirectedEdge *e) {
   return (e->reverseaccess() & vb::kVehicularAccess) == 0;
 }
 
-
-vm::PointLL interp(vm::PointLL a, vm::PointLL b, double frac) {
-  return vm::PointLL(a.AffineCombination(1.0 - frac, frac, b));
-}
-
-// chop the first "dist" length off seg, returning it as the result. this will
-// modify seg!
-std::vector<vm::PointLL> chop_subsegment(std::vector<vm::PointLL> &seg, uint32_t dist) {
-  const size_t len = seg.size();
-  assert(len > 1);
-  std::vector<vm::PointLL> result;
-  result.push_back(seg[0]);
-  double d = 0.0;
-  size_t i = 1;
-  for (; i < len; ++i) {
-    auto segdist = seg[i-1].Distance(seg[i]);
-    if ((d + segdist) >= dist) {
-      double frac = (static_cast<double>(dist) - d) / segdist;
-      auto midpoint = interp(seg[i-1], seg[i], frac);
-      result.push_back(midpoint);
-      // remove used part of seg.
-      seg.erase(seg.begin(), (seg.begin() + (i - 1)));
-      seg[0] = midpoint;
-      break;
-
-    } else {
-      d += segdist;
-      result.push_back(seg[i]);
-    }
-  }
-
-  // used all of seg, and exited the loop by iteration rather than breaking out.
-  if (i == len) {
-    seg.clear();
-  }
-  return result;
-}
-
 pbf::Segment_RoadClass convert_frc(vb::RoadClass rc) {
   assert(pbf::Segment_RoadClass_IsValid(int(rc)));
   return pbf::Segment_RoadClass(int(rc));
@@ -186,7 +148,7 @@ void tiles::split_path(const vb::merge::path& p, const uint32_t total_length) {
       int n = (edge_len / kMaximumLength);
       float dist = static_cast<float>(edge_len) / static_cast<float>(n+1);
       for (int i = 0; i < n; i++) {
-        auto sub_shape = chop_subsegment(shape, std::ceil(dist));
+        auto sub_shape = trim_front(shape, std::ceil(dist));
         output_segment(sub_shape, edge, edge_id, (i==0), false);
         chunks++;
       }

--- a/src/output/tiles.cpp
+++ b/src/output/tiles.cpp
@@ -21,6 +21,7 @@ constexpr uint32_t kMaximumLength = 1000;
 int count = 0;
 int shortsegs = 0;
 int longsegs = 0;
+int chunks = 0;
 float accum = 0.0f;
 
 uint16_t bearing(const std::vector<vm::PointLL> &shape) {
@@ -187,9 +188,11 @@ void tiles::split_path(const vb::merge::path& p, const uint32_t total_length) {
       for (int i = 0; i < n; i++) {
         auto sub_shape = chop_subsegment(shape, std::ceil(dist));
         output_segment(sub_shape, edge, edge_id, (i==0), false);
+        chunks++;
       }
       if (shape.size() > 0) {
         output_segment(shape, edge, edge_id, false, true);
+        chunks++;
       }
 
       // Start a new path at the end of this edge
@@ -398,6 +401,7 @@ void tiles::finish() {
   float avg = accum / count;
   std::cout << "count = " << count << " shortsegs = " << shortsegs <<
           " longsegs " << longsegs << std::endl;
+  std::cout << "chunks " << chunks << std::endl;
   std::cout << "average length = " << avg << std::endl;
 
   // because protobuf Tile messages can be concatenated and there's no footer to


### PR DESCRIPTION
Split edges that are > kMaximumLength into multiple segments. Split segments at nodes that exceed kMaximumLength. Set the at_node hint where applicable (except for edges split in between nodes).

Update GeoJSON output to split segments using same logic as for pbf tiles.