### PR TITLE
Add OSM changeset Id and creation date

### DIFF
--- a/include/osmlr/output/geojson.hpp
+++ b/include/osmlr/output/geojson.hpp
@@ -3,13 +3,16 @@
 
 #include <osmlr/output/output.hpp>
 #include <osmlr/util/tile_writer.hpp>
+#include <string>
 #include <unordered_map>
+#include <ctime>
 
 namespace osmlr {
 namespace output {
 
 struct geojson : public output {
-  geojson(valhalla::baldr::GraphReader &reader, std::string base_dir, size_t max_fds);
+  geojson(valhalla::baldr::GraphReader &reader, std::string base_dir, size_t max_fds,
+          time_t creation_date, const uint64_t osm_changeset_id);
   virtual ~geojson();
 
   void add_path(const valhalla::baldr::merge::path &);
@@ -21,6 +24,9 @@ struct geojson : public output {
   void finish();
 
 private:
+  time_t m_creation_date;
+  std::string m_date_str;
+  uint64_t m_osm_changeset_id;
   valhalla::baldr::GraphReader &m_reader;
   util::tile_writer m_writer;
   std::unordered_map<valhalla::baldr::GraphId, uint32_t> m_tile_path_ids;

--- a/include/osmlr/output/tiles.hpp
+++ b/include/osmlr/output/tiles.hpp
@@ -2,6 +2,7 @@
 #define OSMLR_OUTPUT_TILES_HPP
 
 #include <unordered_map>
+#include <ctime>
 #include <osmlr/output/output.hpp>
 #include <osmlr/util/tile_writer.hpp>
 
@@ -46,7 +47,9 @@ struct lrp {
 };
 
 struct tiles : public output {
-  tiles(valhalla::baldr::GraphReader &reader, std::string base_dir, size_t max_fds, uint32_t max_length = 15000);
+  tiles(valhalla::baldr::GraphReader &reader, std::string base_dir, size_t max_fds,
+        time_t creation_date, const uint64_t osm_changeset_id,
+        uint32_t max_length = 15000);
   virtual ~tiles();
 
   void add_path(const valhalla::baldr::merge::path &p);
@@ -60,6 +63,8 @@ struct tiles : public output {
   void finish();
 
 private:
+  time_t m_creation_date;
+  uint64_t m_osm_changeset_id;
   valhalla::baldr::GraphReader &m_reader;
   util::tile_writer m_writer;
   uint32_t m_max_length;

--- a/src/output/geojson.cpp
+++ b/src/output/geojson.cpp
@@ -34,7 +34,7 @@ geojson::geojson(vb::GraphReader &reader, std::string base_dir, size_t max_fds,
   m_creation_date = creation_date;
   std::tm tm = *std::gmtime(&creation_date);
   char mbstr[100];
-  std::strftime(mbstr, sizeof(mbstr), "%A %c", &tm);
+  std::strftime(mbstr, sizeof(mbstr), "%c %Z", &tm);
   m_date_str = std::string(mbstr);
 }
 

--- a/src/output/geojson.cpp
+++ b/src/output/geojson.cpp
@@ -33,10 +33,9 @@ geojson::geojson(vb::GraphReader &reader, std::string base_dir, size_t max_fds,
   // Change cration date into string plus int
   m_creation_date = creation_date;
   std::tm tm = *std::gmtime(&creation_date);
-  std::stringstream dt;
-  dt.imbue(std::locale("C"));
-  dt << std::put_time(&tm, "%c %Z");
-  m_date_str = dt.str();
+  char mbstr[100];
+  std::strftime(mbstr, sizeof(mbstr), "%A %c", &tm);
+  m_date_str = std::string(mbstr);
 }
 
 geojson::~geojson() {

--- a/src/output/geojson.cpp
+++ b/src/output/geojson.cpp
@@ -33,6 +33,7 @@ geojson::geojson(vb::GraphReader &reader, std::string base_dir, size_t max_fds,
   // Change cration date into string plus int
   m_creation_date = creation_date;
   std::tm tm = *std::gmtime(&creation_date);
+  std::locale::global(std::locale("C"));
   char mbstr[100];
   std::strftime(mbstr, sizeof(mbstr), "%c %Z", &tm);
   m_date_str = std::string(mbstr);

--- a/src/output/geojson.cpp
+++ b/src/output/geojson.cpp
@@ -32,7 +32,7 @@ geojson::geojson(vb::GraphReader &reader, std::string base_dir, size_t max_fds,
   , m_writer(base_dir, "json", max_fds) {
   // Change cration date into string plus int
   m_creation_date = creation_date;
-  std::tm tm = *std::localtime(&creation_date);
+  std::tm tm = *std::gmtime(&creation_date);
   std::stringstream dt;
   dt.imbue(std::locale("C"));
   dt << std::put_time(&tm, "%c %Z");

--- a/src/output/tiles.cpp
+++ b/src/output/tiles.cpp
@@ -111,8 +111,12 @@ FormOfWay form_of_way(const vb::DirectedEdge *e) {
   }
 }
 
-tiles::tiles(vb::GraphReader &reader, std::string base_dir, size_t max_fds, uint32_t max_length)
-  : m_reader(reader)
+tiles::tiles(vb::GraphReader &reader, std::string base_dir, size_t max_fds,
+             time_t creation_date, const uint64_t osm_changeset_id,
+             uint32_t max_length)
+  : m_creation_date(creation_date)
+  , m_osm_changeset_id(osm_changeset_id)
+  , m_reader(reader)
   , m_writer(base_dir, "osmlr", max_fds)
   , m_max_length(max_length) {
 }
@@ -332,6 +336,11 @@ void tiles::output_segment(const std::vector<vm::PointLL>& shape,
 void tiles::output_segment(std::vector<lrp>& lrps,
                            const vb::GraphId& tile_id) {
   pbf::Tile tile;
+
+  // Add creation date and OSM changeset Id
+  tile.set_creation_date(m_creation_date);
+  tile.set_changeset_id(m_osm_changeset_id);
+
   auto *entry = tile.add_entries();
   // don't (yet) support deleted entries, so every entry is a Segment.
   auto *segment = entry->mutable_segment();


### PR DESCRIPTION
Added to both protocol buffer and GeoJSON tiles (GeoJSON has creation date both as Unix time and as a date time string).  Fixes #22 