### PR TITLE
Remove edge list and use consistent float precision

### DIFF
--- a/src/geojson_osmlr.cpp
+++ b/src/geojson_osmlr.cpp
@@ -179,7 +179,7 @@ void create_geojson(std::queue<vb::GraphId>& tilequeue,
 
     // Create the GeoJSON output stream
     std::ostringstream out;
-    out.precision(17);
+    out.precision(9);
     out << "{\"type\":\"FeatureCollection\",\"properties\":{"
         << "\"creation_time\":" << creation_date << ","
         << "\"creation_date\":\"" << date_str << "\","

--- a/src/output/geojson.cpp
+++ b/src/output/geojson.cpp
@@ -198,16 +198,8 @@ void geojson::output_segment(const vb::merge::path &p) {
       << "\"osmlr_id\":" << osmlr_id.value << ","
       << "\"best_frc\":\"" << vb::to_string(best_frc) << "\","
       << "\"oneway\":" << oneway << ","
-      << "\"drive_on_right\":" << drive_on_right << ","
-      << "\"original_edges\":\"";
-
-  first = true;
-  for (auto edge_id : p.m_edges) {
-    if (first) { first = false; } else { out << ", "; }
-    out << edge_id;
-  }
-
-  out << "\"}}";
+      << "\"drive_on_right\":" << drive_on_right;
+  out << "}}";
 
   m_writer.write_to(tile_id, out.str());
   tile_path_itr->second += 1;
@@ -218,7 +210,7 @@ void geojson::output_segment(const std::vector<vm::PointLL>& shape,
                              const vb::DirectedEdge* edge,
                              const vb::GraphId& edgeid) {
   std::ostringstream out;
-  out.precision(17);
+  out.precision(9);
 
   auto tile_id = edgeid.Tile_Base();
 


### PR DESCRIPTION
Valhalla edges do not have persistent Ids so these would only match the version of Valhalla tiles that the OSMLR segments were derived from.
Change output precision to 9 for all latitude and longitude coordinates.